### PR TITLE
Minor typo/method fixes and a new method for threeDTool, new tests

### DIFF
--- a/ThreeDTool/line.py
+++ b/ThreeDTool/line.py
@@ -307,7 +307,7 @@ class Line_segment(Line):
         self.border_x.sort()
         self.border_y.sort()
         self.border_z.sort()
-        self.lenth = np.linalg.norm(self.point1 - self.point2)
+        self.length = np.linalg.norm(self.point1 - self.point2)
 
     def info(self) -> None:
         """

--- a/ThreeDTool/polygon.py
+++ b/ThreeDTool/polygon.py
@@ -162,22 +162,23 @@ class Polygon:
         начиная с этой вершины. Если после сортировки массивы оказываются одинаковы, то многоугольники одинаковы.
         :param polygon: изучаемый полигон
         :type polygon: Polygon
-        :return: ndarray[Any, dtype[Any]] | None
+        :return: bool | None
         """
         vert1 = self.vertices
         vert2 = polygon.vertices
         sort_vert = vert1[0]
-        indices = np.where((vert2 == sort_vert).all(axis=1))[0]
+        indices = np.where((np.isclose(sort_vert, vert2, 1e-6)).all(axis=1))[0]
         if self.vertices.shape != polygon.vertices.shape:
             return False
         else:
             if indices.shape == (0,):
                 return False
             elif indices.shape == (1,):
-                vert2 = np.roll(vert2, indices[0])
+                vert2 = np.roll(vert2, -indices[0], axis=0)
+                vert2_rev = np.vstack([vert2[0], vert2[-1:0:-1]])
             else:
                 raise Exception("Пришел сломанный многоугольник")
-        if np.allclose(vert1, vert2, 1e-6):
+        if np.allclose(vert1, vert2, 1e-6) or np.allclose(vert1, vert2_rev, 1e-6):
             return True
         else:
             return False

--- a/ThreeDTool/polygon.py
+++ b/ThreeDTool/polygon.py
@@ -86,7 +86,7 @@ class Polygon:
 
     def intersection_analyze(self, polygon: Polygon):
         """
-        Функция находит точки пересечения с входящим прямоугольником
+        Функция находит точки пересечения с входящим многоугольником
         """
         from .threeDTool import point_from_segment_segment_intersection
         points = np.array([0, 0, 0])
@@ -231,8 +231,8 @@ class Polygon:
         """
         from .threeDTool import point_from_beam_segment_intersection, point_comparison
         line = Line()
-        tets_point = np.array(self._barycenter)
-        line.line_create_from_points(point, tets_point)
+        test_point = np.array(self._barycenter)
+        line.line_create_from_points(point, test_point)
         arr = np.array([[0, 0, 0]])
         for i, item in enumerate(self._line_segments):
             p = np.array(point_from_beam_segment_intersection(line, item))
@@ -253,7 +253,7 @@ class Polygon:
 
     def points_from_polygon_polygon_intersection(self, polygon: Polygon) -> ndarray[Any, dtype[Any]] | None:
         """
-        Функция возвращает пересечение входящего полигона с self полигоном
+        Функция возвращает точки пересечения входящего полигона с self полигоном
         :param polygon: изучаемый полигон
         :type polygon: Polygon
         :return: ndarray[Any, dtype[Any]] | None
@@ -268,24 +268,24 @@ class Polygon:
             plane1.create_plane_from_triangle(self._vertices[0:3], create_normal=True)
             plane2 = Plane()
             plane2.create_plane_from_triangle(polygon._vertices[0:3], create_normal=True)
-            points = np.array([[0, 0, 0]])
+            points = np.array([]).reshape(0, 3)
             var = position_analyzer_of_plane_plane(plane1, plane2)
-            points_return = np.array([[0, 0, 0]])
+            points_return = np.array([]).reshape(0, 3)
             if var == 0:
                 for segment in polygon._line_segments:
                     point_in = point_from_plane_segment_intersection(segment, plane1)
                     if point_in is not None:
                         points = np.vstack([points, point_in])
-                points = points[1:]
-                if points.shape == (0,):
+                points = points
+                if points.shape == (0, 3):
                     return None
                 else:
                     for point in points:
                         var = self.point_analyze(point)
                         if var:
                             points_return = np.vstack([points_return, point])
-                if points_return.shape != (0,):
-                    return points_return[1:]
+                if points_return.shape != (0, 3):
+                    return points_return
                 else:
                     return None
             elif var == 1:
@@ -294,10 +294,10 @@ class Polygon:
                         point_int = point_from_segment_segment_intersection(segment, self_segment)
                         if point_int is not None:
                             points_return = np.vstack([points_return, point_int])
-            if points_return.shape == (0,):
+            if points_return.shape == (0, 3):
                 return None
             else:
-                return points_return[1:]
+                return points_return
 
 
 class Polygon_2D:

--- a/ThreeDTool/tests/test_Polygon.py
+++ b/ThreeDTool/tests/test_Polygon.py
@@ -1,17 +1,41 @@
 from ..polygon import Polygon
 import numpy as np
 
+
 class TestPolygon:
+    # polygons_equal ---------------------------
     def test_polygons_equal(self):
         pol1 = Polygon(np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]]))
         pol2 = Polygon(np.array([[1, 0, 0], [1, 1, 0], [0, 1, 0], [0, 0, 0]]))
         assert pol1.polygons_equal(pol2)
 
     def test_polygons_equal2(self):
+        pol1 = Polygon(np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]]))
+        pol2 = Polygon(np.array([[1, 0, 0], [0, 0, 0], [0, 1, 0], [1, 1, 0]]))
+        assert pol1.polygons_equal(pol2)
+
+    def test_polygons_equal3(self):
+        pol1 = Polygon(np.array([[0, 0, 0.000000004], [1, -0.000000003, 0], [1, 1, 0], [0, 1, 0]]))
+        pol2 = Polygon(np.array([[1, 0.000000003, 0], [0, 0, 0], [0, 1, 0], [1.000000004, 1, 0]]))
+        assert pol1.polygons_equal(pol2)
+
+    # incorrect
+    def test_polygons_equal4(self):
         pol1 = Polygon(np.array([[0, 0, 1], [1, 0, 1], [1, 1, 1], [0, 1, 1]]))
         pol2 = Polygon(np.array([[1.5, 0, 0], [1.5, 1, 0], [0.5, 1, 0], [0.5, 0, 0]]))
         assert not pol1.polygons_equal(pol2)
 
+    def test_polygons_equal5(self):
+        pol1 = Polygon(np.array([[0, 0, 0], [1, 0.00000004, 0], [1, 1, 0], [0, 1, 0]]))
+        pol2 = Polygon(np.array([[1, 0, 0], [0, 0, 0], [0, 1, 0], [1, 1, 0]]))
+        assert not pol1.polygons_equal(pol2)
+
+    def test_polygons_equal6(self):
+        pol1 = Polygon(np.array([[0, 0, 0.], [1, -0.000000003, 0], [1, 1, 0], [0, 1, 0]]))
+        pol2 = Polygon(np.array([[1, 0.000000009, 0], [0, 0, 0], [0, 1, 0], [1, 1, 0]]))
+        assert not pol1.polygons_equal(pol2)
+
+    # points_from_polygon_polygon_intersection_and_rot_v ---------------------------
     def test_points_from_polygon_polygon_intersection_and_rot_v(self):
         from ..threeDTool import rot_v
         pol1 = Polygon(np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]]))

--- a/ThreeDTool/tests/test_threedtool.py
+++ b/ThreeDTool/tests/test_threedtool.py
@@ -58,10 +58,11 @@ class TestThreedtool:
         vector7 = [-1.44646, 1.673453536, 365.456772]
         vector8 = [1.4353672, -1.67345 * 256, 53455.456772484]
         var2 = [collinearity_vectors(vector1, vector2),
-               collinearity_vectors(vector3, vector4),
-               collinearity_vectors(vector5, vector6),
-               collinearity_vectors(vector7, vector8)]
+                collinearity_vectors(vector3, vector4),
+                collinearity_vectors(vector5, vector6),
+                collinearity_vectors(vector7, vector8)]
         assert np.all(var) and not np.all(var2)
+
     def test_collinearity_vectors_list(self):
         vector1 = [19, 19, 1]
         vector2 = [-38, -38, -2]
@@ -157,3 +158,76 @@ class TestThreedtool:
         line = Line(1, -1, 0, 1, -1, 0)
         point = point_from_line_segment_intersection(line, segment)
         assert np.allclose(point, [0., 0., 0.], 1e-8)
+
+    # rectangle_from_three_points ---------------------------
+    def test_rectangle_from_three_points_1(self):
+        polygon_1 = Polygon(np.array([[0, 0, 0], [2, 0, 0], [2, 2, 0], [0, 2, 0]]))
+        polygon_2 = rectangle_from_three_points([0, 0, 0], [2, 0, 0], [0, 2, 0])
+        assert polygon_1.polygons_equal(polygon_2)
+
+    def test_rectangle_from_three_points_2(self):
+        polygon_1 = Polygon(np.array([[2, 1, 0], [5, -1, 0], [1, -7, 0], [-2, -5, 0]]))
+        polygon_2 = rectangle_from_three_points([2, 1, 0], [5, -1, 0], [-3.95, -3.7, 0])
+        assert polygon_1.polygons_equal(polygon_2)
+
+    def test_rectangle_from_three_points_3(self):
+        polygon_1 = Polygon(np.array([[-10, 8.6, 2.4], [7.2, 8.6, 2.4], [7.2, -2.8, -9.4], [-10, -2.8, -9.4]]))
+        polygon_2 = rectangle_from_three_points([7.2, 8.6, 2.4], [-10, 8.6, 2.4], [18, -2.8, -9.4])
+        assert polygon_1.polygons_equal(polygon_2)
+
+    def test_rectangle_from_three_points_4(self):
+        polygon_1 = Polygon(np.array([[-3.6, -7.2, 4.5], [9.3, 5.5, -2.5], [5.43199016, 3.4200798, -13.40175907],
+                                      [-7.46800984, -9.2799202, -6.40175907]]))
+        polygon_2 = rectangle_from_three_points([9.3, 5.5, -2.5], [5.43199016, 3.4200798, -13.40175907],
+                                                [-3.6, -7.2, 4.5])
+        assert polygon_1.polygons_equal(polygon_2)
+
+        # incorrect
+
+    def test_rectangle_from_three_points_5(self):
+        polygon_1 = Polygon(np.array([[0, 0, 0], [2, 0, 0], [2, 2, 1], [0, 2, 1]]))
+        polygon_2 = rectangle_from_three_points([0, 0, 0], [2, 0, 0], [0, 2, 0])
+        assert not polygon_1.polygons_equal(polygon_2)
+
+    def test_rectangle_from_three_points_6(self):
+        polygon_1 = Polygon(np.array([[0, 0, 0], [2, 0, 0], [2, 2, 0], [0, 2, 0]]))
+        polygon_2 = rectangle_from_three_points([0, 0, 0], [2, 0, 0], [0, 2, 0])
+        assert polygon_1.polygons_equal(polygon_2)
+
+    def test_rectangle_from_three_points_7(self):
+        polygon_1 = Polygon(np.array([[0, 0, 0], [2, 0, 0], [2, 2, 0], [0, 2, 0]]))
+        polygon_2 = rectangle_from_three_points([0, 0, 0], [2, 0, 0], [1, 1, 0])
+        assert not polygon_1.polygons_equal(polygon_2)
+
+    # rectangle_from_center ---------------------------
+    def test_rectangle_from_center_1(self):
+        polygon_1 = Polygon(np.array([[5, 1, 0], [-5, 1, 0], [-5, -1, 0], [5, -1, 0]]))
+        polygon_2 = rectangle_from_center([0, 0, 0], 10, 2, [1, 0, 0], [0, 0, 1])
+        assert polygon_1.polygons_equal(polygon_2)
+
+    def test_rectangle_from_center_2(self):
+        polygon_1 = Polygon(np.array([[2, 1, 0], [5, -1, 0], [1, -7, 0], [-2, -5, 0]]))
+        polygon_2 = rectangle_from_center([1.5, -3, 0], 3.605551275464, 7.211102550928, [-3, 2, 0], [0, 0, 1])
+        assert polygon_1.polygons_equal(polygon_2)
+
+
+    def test_rectangle_from_center_3(self):
+        polygon_1 = Polygon(np.array([[-3.6, -7.2, 4.5], [9.3, 5.5, -2.5], [5.43199016, 3.4200798, -13.40175907],
+                                      [-7.46800984, -9.2799202, -6.40175907]]))
+        polygon_2 = rectangle_from_center([0.91599508, -1.8899601, -4.45087954], 19.4087609, 11.7531238,
+                                          [4.99501731, 4.91757518, -2.71047451], [-4.03467954, 4.42221572, 0.5878248])
+        assert polygon_1.polygons_equal(polygon_2)
+
+        # incorrect
+
+    def test_rectangle_from_center_4(self):
+        try:
+            polygon_1 = Polygon(np.array([[0, 0, 0], [2, 0, 0], [2, 2, 0], [0, 2, 0]]))
+            polygon_2 = rectangle_from_center([1, 1, 0], 1, 2, [1, 0, 0], [2, 3, 1])
+        except(ValueError): assert True
+        else: assert False
+
+    def test_rectangle_from_center_5(self):
+        polygon_1 = Polygon(np.array([[0, 0, 0], [2, 0, 0], [2, 2, 0], [0, 2, 0]]))
+        polygon_2 = rectangle_from_center([1, 1, 0], 1, 2, [1, 0, 0], [0, 1, 0])
+        assert not polygon_1.polygons_equal(polygon_2)

--- a/ThreeDTool/threeDTool.py
+++ b/ThreeDTool/threeDTool.py
@@ -436,10 +436,10 @@ def distance_between_two_points(point1: float | int, point2: float | int) -> flo
 
 def vector_from_two_points(point1, point2) -> np.ndarray:
     """
-    Данная функция создает вектор из двух точек
+    Данная функция создает вектор из двух точек, направленный из point1 в point2
     :param point1: Первая точка типа [x, y, z] или [x, y]
     :type point1: list or np.ndarray
-    :param point2: Первая точка типа [x, y, z] или [x, y]
+    :param point2: Вторая точка типа [x, y, z] или [x, y]
     :type point2: list or np.ndarray
     :return: np.ndarray
     """
@@ -452,7 +452,7 @@ def vector_from_two_points(point1, point2) -> np.ndarray:
 
 def normal_of_triangle(vertex1, vertex2, vertex3) -> np.ndarray:
     """
-    Функция генерирует вектор нормали треугольника по правиле правого винта
+    Функция генерирует вектор нормали треугольника по правилу правого винта
     :param vertex1: Первая вершина треугольника
     :type vertex1: list or np.ndarray
     :param vertex2: Вторая вершина треугольника
@@ -979,6 +979,46 @@ def rectangle_from_three_points(point1: list | ndarray, point2: list | ndarray, 
     vertices = np.array([point1, point2, B1, A1])
     return Polygon(vertices)
 
+def rectangle_from_center(center_point: list | ndarray, length: int | float, width: int | float,
+                          vector_length: list | ndarray,
+                          vector_plane: list | ndarray) -> Polygon:
+    """
+    Функция создает прямоугольник по центру, длине, ширине и двум векторам, один из которых коллинеарен длине, а второй
+    лежит в плоскости прямоугольника
+    Вектор коллинеарный ширине является направляющим для прямой пересечения плоскости прямоугольника и плоскости,
+    нормальной к вектору длины и проходящей через точку центра.
+
+    :param center_point: точка центра
+    :type center_point: list | ndarray
+    :param length: Длина
+    :type length: list | ndarray
+    :param width: Ширина
+    :type width: list | ndarray
+    :param vector_length: Вектор, коллинеарный длине
+    :type vector_length: list | ndarray
+    :param vector_plane: Вектор, лежащий в плоскости прямоугольника, неколлинеарный vec_length
+    :type vector_plane: list | ndarray
+    :return: Polygon
+    """
+    from .polygon import Polygon
+    half_length = length / 2
+    half_width = width / 2
+    if collinearity_vectors(vector_length, vector_plane):
+        raise(ValueError("Vectors are collinear"))
+    plane = Plane()
+    plane.create_plane_from_triangle([[0, 0, 0], vector_length, vector_plane], create_normal=True)
+    plane_norm = Plane()
+    plane_norm.create_plane_from_triangle([vector_length, center_point, [0, 0, 0], [0, 0, 0]], create_normal=False)
+    line = Line()
+    line.line_from_planes(plane1=plane, plane2=plane_norm)
+    vector_width = line.coeffs()[3:]
+
+    point1 = center_point + normalization(vector_length, half_length) + normalization(vector_width, half_width)
+    point2 = center_point + normalization(vector_length, half_length) - normalization(vector_width, half_width)
+    point3 = center_point - normalization(vector_length, half_length) - normalization(vector_width, half_width)
+    point4 = center_point - normalization(vector_length, half_length) + normalization(vector_width, half_width)
+    vertices = np.array([point1, point2, point3, point4])
+    return Polygon(vertices)
 
 def parse_stl(file):
     """


### PR DESCRIPTION
+ был исправлен баг где у Polygon.points_from_polygon_polygon_intersection (над названием еще надо подумать) возвращался пустой массив, а не None

+ Изначально метод threeDTools.rectangle_from_center брал любой вектор в плоскости прямоугольника, что на идейном уровне неплохо звучит, но на практике оказалось крайне неудобным. Изменил на вектор нормали к плоскости прямоугольника: стало более интуитивно и чуть удобнее с точки зрения геометрии

+ Проверка многоугольников на равенство не узнавала равные многоугольники (исправлено), заданые в разных направлениях обхода, и требовала полного совпадения точек, изменено на точность вплоть до 6 знака после запятой